### PR TITLE
[FIX] Update quantity info when record is deleted

### DIFF
--- a/oa_partner_stock_offer/models/supplier_stock.py
+++ b/oa_partner_stock_offer/models/supplier_stock.py
@@ -97,3 +97,14 @@ class SupplierStock(models.Model):
         res =super(SupplierStock,self).create(vals)
         res._get_quantity()
         return res
+
+    @api.multi
+    def unlink(self):
+        product_ids = []
+        for ps in self:
+            product_ids.append(ps.product_id.id)
+        res = super(SupplierStock, self).unlink()
+        related_ps = self.search([('product_id', 'in', product_ids)])
+        if related_ps:
+            related_ps._get_quantity()
+        return res


### PR DESCRIPTION
When partner stock is deleted, `_get_quantity` needs to be run in order to update the `has_duplicates` of other partner stock records.