### PR TITLE
[FIX] Access error for portal user

### DIFF
--- a/tko_web_sessions_management/main.py
+++ b/tko_web_sessions_management/main.py
@@ -98,7 +98,7 @@ class TkobrSessionMixin(object):
                     else:
                         # check user groups calendar
                         for group in user.groups_id:
-                            if group.login_calendar_id:
+                            if group.sudo().login_calendar_id:
                                 calendar_set += 1
                                 attendances = attendance_obj.search(request.cr,
                                                                     request.uid, [('calendar_id', '=',


### PR DESCRIPTION
- Since portal user does not have access to the `res.group`, hence we need to use `sudo()` to grant the access

Related PR: https://github.com/thinkopensolutions/tko-addons/pull/919