### PR TITLE
[FIX] Brand of partner stock kanban view

### DIFF
--- a/oa_partner_stock_offer/models/supplier_stock.py
+++ b/oa_partner_stock_offer/models/supplier_stock.py
@@ -41,6 +41,10 @@ class SupplierStock(models.Model):
     short_loc_name = fields.Char(
         "Location",
         related='partner_loc_id.short_loc')
+    brand = fields.Char(
+        related='prod_cat_selection.name',
+        string='Brand',
+    )
 
 
     # # Overwriting display_name's method for Supplier Access User

--- a/oa_partner_stock_offer/views/partner_stock_template_views.xml
+++ b/oa_partner_stock_offer/views/partner_stock_template_views.xml
@@ -19,6 +19,7 @@
                                 </h4>
                                 <div name="tags"/>
                                 <ul>
+                                    <li>Brand: <field name="brand"/></li>
                                     <li>Retail <field name="currency_id"/>: <field name="retail_in_currency"></field></li>
                                     <li>Retail HKD: <field name="hk_retail"/></li>
                                     <li>Quantity: <field name="partner_qty"/></li>


### PR DESCRIPTION
- Adding a related field for the brand name for `supplier.stock`